### PR TITLE
Fix: exit from picker

### DIFF
--- a/android/src/main/kotlin/com/sidlatau/flutterdocumentpicker/FlutterDocumentPickerDelegate.kt
+++ b/android/src/main/kotlin/com/sidlatau/flutterdocumentpicker/FlutterDocumentPickerDelegate.kt
@@ -68,7 +68,7 @@ class FlutterDocumentPickerDelegate(
                 val channelResult = channelResult
                 val allowedFileExtensions = allowedFileExtensions
                 val intersectedExtension = allowedFileExtensions?.intersect(params.map { param -> param.extension }.toSet()) ?: setOf()
-                if (params != null) {
+                if (params != null && params.isNotEmpty()) {
                     if (allowedFileExtensions != null && intersectedExtension.isNotEmpty()) {
                         channelResult?.error("extension_mismatch", "Picked file extension mismatch!", intersectedExtension.first())
                     } else {


### PR DESCRIPTION
when you exit the picker without selecting a file, the plugin does not return anything